### PR TITLE
gitignore update

### DIFF
--- a/Source/.gitignore
+++ b/Source/.gitignore
@@ -1,3 +1,5 @@
+*.hot-update.json
+
 .DS_Store
 node_modules
 /dist


### PR DESCRIPTION
I updated the gitignore to include files ending in .hot-update.json. These are small metadata files that are generated whenever anyone runs `npm run watch` that should not be be included in source control. 